### PR TITLE
Fix tag-template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
 name-template: "release-drafter-practice $NEXT_PATCH_VERSION"
-tag-template: "v$NEXT_PATCH_VERSION"
+tag-template: "$NEXT_PATCH_VERSION"
 version-template: "v$MAJOR.$MINOR.$PATCH"
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
 template: |


### PR DESCRIPTION
Fix tag template to avoid double v (like vv0.0.1) in release draft page.
